### PR TITLE
Fix UV stats placeholder layout to prevent UI jumping

### DIFF
--- a/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
@@ -187,6 +187,10 @@ class _UIBuilderMixin:
     _UV_STATS_LABEL_U = "u<sub>x</sub>"
     _UV_STATS_LABEL_V = "u<sub>y</sub>"
 
+    # Shown in the title in every state (placeholder and populated) so the unit
+    # is always visible and the title length never changes when values arrive.
+    _UV_STATS_UNIT = "µm/s"
+
     def _build_uv_stats_label(self) -> QLabel:
         lbl = QLabel()
         lbl.setTextFormat(Qt.RichText)
@@ -199,9 +203,23 @@ class _UIBuilderMixin:
         return lbl
 
     def _clear_uv_stats(self) -> None:
-        # Same table as the populated state but with dash cells, so the
-        # reserved height matches and nothing jumps once values arrive.
-        self.lbl_uv_stats.setText(self._format_uv_stats_html(None, None, ""))
+        # Same table as the populated state -- same title (with unit) and same
+        # row count -- but with placeholder cells, so the reserved height
+        # matches and nothing jumps once values arrive.
+        self.lbl_uv_stats.setText(
+            self._format_uv_stats_html(None, None, self._UV_STATS_UNIT)
+        )
+
+    def _reserve_uv_stats_height(self) -> None:
+        # Lock the stats box to the height of the placeholder table so that
+        # "Compute field" only swaps dashes for values and never grows the box,
+        # which would push the controls below it down. Measured at the panel's
+        # minimum width (where text wraps the most) so the reservation still
+        # holds when the window is dragged narrow. Call once after fonts are
+        # set, while the placeholder is showing.
+        height = self.lbl_uv_stats.heightForWidth(self._LEFT_MIN_W)
+        if height > 0:
+            self.lbl_uv_stats.setFixedHeight(height)
 
     def _set_uv_stats(self, u_stats, v_stats, unit: str = "") -> None:
         self.lbl_uv_stats.setText(self._format_uv_stats_html(u_stats, v_stats, unit))
@@ -239,9 +257,12 @@ class _UIBuilderMixin:
         width = cls._UV_STATS_DATA_COL_WIDTH
         if stats is None:
             # One right-aligned dash per column (not a single centered span) so
-            # the placeholder lines up with the values that later replace it.
+            # the placeholder reserves the same width and height as the values
+            # that later replace it. Rendered transparent so the table reads as
+            # blank cells until "Compute field" fills them in.
             cells = "".join(
-                f"<td align='right' width='{width}'>&mdash;</td>"
+                f"<td align='right' width='{width}' style='color:transparent;'>"
+                f"&mdash;</td>"
                 for _ in cls._UV_STATS_COLUMNS
             )
             return f"<tr>{label}{cells}</tr>"

--- a/src/opennta/application/tab_analysis/dialogs/numerical/dialog.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/dialog.py
@@ -41,6 +41,7 @@ class NumericalFieldDialog(
 
         self._build_ui()
         self.setFont(get_app_font())
+        self._reserve_uv_stats_height()
         self._init_plot_slots()
 
         self.canvas.mpl_connect("resize_event", self._on_canvas_resize)
@@ -103,7 +104,7 @@ class NumericalFieldDialog(
         fps = float(self.config.fps)
         u_stats = component_stats(self.stats.mean_dx * fps)
         v_stats = component_stats(self.stats.mean_dy * fps)
-        self._set_uv_stats(u_stats, v_stats, unit="µm/s")
+        self._set_uv_stats(u_stats, v_stats, unit=self._UV_STATS_UNIT)
 
     def _apply_smoothing(self) -> None:
         if self.stats is None:


### PR DESCRIPTION
## Summary
This PR fixes a layout issue where the UV statistics display box would grow when computed values arrived, causing controls below it to shift down. The solution ensures the placeholder state reserves the exact same height as the populated state.

## Key Changes
- **Added `_UV_STATS_UNIT` constant**: Extracted the unit string ("µm/s") to a class constant so it's consistently used in both placeholder and populated states, keeping the title length constant
- **Updated placeholder rendering**: Changed placeholder dashes from visible to transparent (`color:transparent`) so they reserve space without being visually apparent
- **Added `_reserve_uv_stats_height()` method**: New method that locks the stats label to a fixed height based on the placeholder's rendered size, preventing the box from growing when values arrive
- **Integrated height reservation**: Call `_reserve_uv_stats_height()` during initialization after fonts are set and while the placeholder is displayed
- **Updated `_clear_uv_stats()`**: Now passes the unit constant to the formatter so the placeholder title includes the unit, matching the populated state

## Implementation Details
- The placeholder uses the same table structure (same title with unit, same row count) as the populated state, but with transparent dashes instead of visible ones
- Height is measured at the panel's minimum width to account for text wrapping, ensuring the reservation holds even when the window is resized narrow
- The unit is now centralized in `_UV_STATS_UNIT` to avoid duplication and ensure consistency between states

https://claude.ai/code/session_01UxiTFDGDmPTZR6iehvra87