### PR TITLE
Rename CI95 to SE (standard error) in field smoothing

### DIFF
--- a/src/opennta/analysis/numerical_field/__init__.py
+++ b/src/opennta/analysis/numerical_field/__init__.py
@@ -1,7 +1,7 @@
 """Numerical velocity field for spatially-varying drift correction."""
 
 from .field_sampler import FieldSampler
-from .field_smoother import ci95_weighted_gaussian_smooth
+from .field_smoother import se_weighted_gaussian_smooth
 from .field_stats import ComponentStats, component_stats
 from .node_field import NodeField, build_node_field
 from .numerical_corrector import NumericalCorrector, NumericalDiagnosticState
@@ -13,7 +13,7 @@ __all__ = [
     "FieldStats",
     "NumericalFieldParams",
     "compute_velocity_field",
-    "ci95_weighted_gaussian_smooth",
+    "se_weighted_gaussian_smooth",
     "ComponentStats",
     "component_stats",
     "FieldSampler",

--- a/src/opennta/analysis/numerical_field/field_smoother.py
+++ b/src/opennta/analysis/numerical_field/field_smoother.py
@@ -4,10 +4,10 @@ import numpy as np
 from numpy.typing import NDArray
 
 
-def ci95_weighted_gaussian_smooth(
+def se_weighted_gaussian_smooth(
     mean_dx: NDArray[np.floating],
     mean_dy: NDArray[np.floating],
-    ci95_vec: NDArray[np.floating],
+    se_vec: NDArray[np.floating],
     count: NDArray[np.floating],
     min_count: int = 5,
     eps: float = 1e-12,
@@ -15,15 +15,17 @@ def ci95_weighted_gaussian_smooth(
     n_iter: int = 2,
     sigma: float | None = None,
 ) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
-    # CI-weighted Gaussian spatial smoothing.
+    # SE-weighted Gaussian spatial smoothing.
     #
     # At every iteration each cell is replaced by a weighted average of its
     # neighbours within a ksize x ksize window. Weight at offset (dj, di) is
-    #     G(dj, di) * 1 / (ci95^2 + eps)  for valid cells, else 0,
-    # where G is an isotropic 2D Gaussian of width sigma.
+    #     G(dj, di) * 1 / (se^2 + eps)  for valid cells, else 0,
+    # where G is an isotropic 2D Gaussian of width sigma and se is the standard
+    # error of the cell's mean velocity. Since se^2 is the variance of that
+    # mean, 1 / se^2 is inverse-variance (precision) weighting.
     #
     # Invalid cells (count < min_count, count < 2, non-finite or non-positive
-    # ci95) carry zero reliability weight and are filled in from valid
+    # se) carry zero reliability weight and are filled in from valid
     # neighbours (diffusion-like). Cells whose denominator is zero in a given
     # iteration (no valid neighbour inside the kernel) are left unchanged.
     #
@@ -45,11 +47,11 @@ def ci95_weighted_gaussian_smooth(
                           / (2.0 * sigma * sigma))
 
     pass_N = count >= int(min_count)
-    pass_CI = (count >= 2) & np.isfinite(ci95_vec) & (ci95_vec > 0)
-    pass_both = pass_N & pass_CI
+    pass_se = (count >= 2) & np.isfinite(se_vec) & (se_vec > 0)
+    pass_both = pass_N & pass_se
 
-    w = np.zeros_like(ci95_vec, dtype=float)
-    w[pass_both] = 1.0 / (ci95_vec[pass_both] ** 2 + eps)
+    w = np.zeros_like(se_vec, dtype=float)
+    w[pass_both] = 1.0 / (se_vec[pass_both] ** 2 + eps)
 
     u_cur = np.where(pass_both & np.isfinite(mean_dx), mean_dx, 0.0).astype(float)
     v_cur = np.where(pass_both & np.isfinite(mean_dy), mean_dy, 0.0).astype(float)
@@ -86,7 +88,7 @@ def ci95_weighted_gaussian_smooth(
                 u_nb = u_cur[src_r0:src_r1, src_c0:src_c1]
                 v_nb = v_cur[src_r0:src_r1, src_c0:src_c1]
 
-                contrib = g * w_nb  # Gaussian * inverse-CI^2 weight
+                contrib = g * w_nb  # Gaussian * inverse-variance (1/se^2) weight
                 num_u[dst_r0:dst_r1, dst_c0:dst_c1] += contrib * u_nb
                 num_v[dst_r0:dst_r1, dst_c0:dst_c1] += contrib * v_nb
                 den[dst_r0:dst_r1, dst_c0:dst_c1] += contrib

--- a/src/opennta/analysis/numerical_field/numerical_corrector.py
+++ b/src/opennta/analysis/numerical_field/numerical_corrector.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from ..drift_corrector import DriftCorrector, ExportField, register_corrector
 from .field_sampler import FieldSampler
-from .field_smoother import ci95_weighted_gaussian_smooth
+from .field_smoother import se_weighted_gaussian_smooth
 from .node_field import build_node_field
 from .types import FieldStats, NumericalFieldParams
 from .velocity_field import compute_velocity_field
@@ -138,10 +138,10 @@ class NumericalCorrector(DriftCorrector):
             outlier_k=p.outlier_k,
         )
 
-        u_sm, v_sm = ci95_weighted_gaussian_smooth(
+        u_sm, v_sm = se_weighted_gaussian_smooth(
             mean_dx=stats.mean_dx,
             mean_dy=stats.mean_dy,
-            ci95_vec=stats.ci95_vec,
+            se_vec=stats.se_vec,
             count=stats.count,
             min_count=p.min_count,
             ksize=p.ksize,

--- a/src/opennta/analysis/numerical_field/types.py
+++ b/src/opennta/analysis/numerical_field/types.py
@@ -19,7 +19,7 @@ class FieldStats:
     std_dx: NDArray[np.floating]
     std_dy: NDArray[np.floating]
     sigma_vec: NDArray[np.floating]
-    ci95_vec: NDArray[np.floating]
+    se_vec: NDArray[np.floating]
 
 
 @dataclass

--- a/src/opennta/analysis/numerical_field/velocity_field.py
+++ b/src/opennta/analysis/numerical_field/velocity_field.py
@@ -83,7 +83,6 @@ def compute_velocity_field(
 
     sigma_vec = np.sqrt(std_dx ** 2 + std_dy ** 2)
     se_vec = sigma_vec / np.sqrt(np.where(ok1, count, np.nan))
-    ci95_vec = 1.96 * se_vec
 
     return FieldStats(
         n_windows=n,
@@ -95,7 +94,7 @@ def compute_velocity_field(
         std_dx=std_dx,
         std_dy=std_dy,
         sigma_vec=sigma_vec,
-        ci95_vec=ci95_vec,
+        se_vec=se_vec,
     )
 
 

--- a/src/opennta/application/tab_analysis/dialogs/numerical/_plot_builder.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_plot_builder.py
@@ -34,8 +34,8 @@ class _PlotBuilderMixin:
         # Three-column layout:
         #   col 0 (2 rows): tracks
         #   col 1 row 0  : mean drift
-        #   col 1 row 1  : CI95
-        #   col 2 (2 rows): CI-weighted smoothed
+        #   col 1 row 1  : SE
+        #   col 2 (2 rows): SE-weighted smoothed
         gs = GridSpec(
             2,
             3,
@@ -87,7 +87,7 @@ class _PlotBuilderMixin:
         # Stored field is in um/frame; display in um/s via fps scaling.
         fps = float(self.config.fps)
         vbar = np.hypot(self.stats.mean_dx, self.stats.mean_dy) * fps
-        ci95_vec = self.stats.ci95_vec * fps
+        se_vec = self.stats.se_vec * fps
         vbar_smoothed = None
 
         if self._use_smoothed and self.smoothed_u is not None and self.smoothed_v is not None:
@@ -96,7 +96,7 @@ class _PlotBuilderMixin:
         return [
             (None, track_cmap, track_title, track_unit),
             (vbar, specs[1][1], specs[1][0], specs[1][2]),
-            (ci95_vec, specs[2][1], specs[2][0], specs[2][2]),
+            (se_vec, specs[2][1], specs[2][0], specs[2][2]),
             (vbar_smoothed, specs[3][1], specs[3][0], specs[3][2]),
         ]
 

--- a/src/opennta/application/tab_analysis/dialogs/numerical/_plot_style.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_plot_style.py
@@ -114,13 +114,13 @@ def recolor_for_export(fig: Figure, color: str = "black") -> None:
 PLOT_SPECS = (
     ("Tracks on grid", None, ""),
     ("Mean velocity on grid", "viridis", "µm/s"),
-    (r"CI$_{95}$", "magma", "µm/s"),
+    ("Standard error", "magma", "µm/s"),
     ("Smoothed velocity-field", "viridis", "µm/s"),
 )
 
 TRACKS_INDEX = 0
 MEAN_INDEX = 1
-CI95_INDEX = 2
+SE_INDEX = 2
 SMOOTHED_INDEX = 3
 
 FS_TITLE = 13

--- a/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
@@ -311,7 +311,7 @@ class _UIBuilderMixin:
             self.le_nodes.setText(str(self.sb_nwin.value()))
 
     def _build_smoothing_group(self) -> QGroupBox:
-        box = QGroupBox("CI-weighted smoothing")
+        box = QGroupBox("SE-weighted smoothing")
 
         vbox = QVBoxLayout(box)
         vbox.setContentsMargins(10, 12, 10, 10)
@@ -354,7 +354,7 @@ class _UIBuilderMixin:
             "\">"
             "<span style=\"font-style:italic;\">w</span>(&#916;j, &#916;i)"
             " = <span style=\"font-style:italic;\">G</span>(&#916;j, &#916;i)"
-            " &middot; 1 / (CI<sub>95</sub><sup>2</sup> + &#949;)"
+            " &middot; 1 / (SE<sup>2</sup> + &#949;)"
             "<br>"
             "<span style=\"font-style:italic;\">G</span>(&#916;j, &#916;i)"
             " = exp&nbsp;[ - (&#916;j<sup>2</sup> + &#916;i<sup>2</sup>) / (2&#963;<sup>2</sup>) ]"

--- a/src/opennta/application/tab_analysis/dialogs/numerical/diagnostics.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/diagnostics.py
@@ -34,7 +34,7 @@ def save_numerical_diagnostics(
 
     # Stored field is in um/frame; display in um/s to match the dialog.
     vbar = np.hypot(stats.mean_dx, stats.mean_dy) * fps
-    ci95_vec = stats.ci95_vec * fps
+    se_vec = stats.se_vec * fps
     if u_sm is not None and v_sm is not None:
         vbar_sm = np.hypot(u_sm, v_sm) * fps
     else:
@@ -52,7 +52,7 @@ def save_numerical_diagnostics(
     specs = _ps.PLOT_SPECS
     ax_tracks = flat_axes[0]
     ax_mean = flat_axes[1]
-    ax_ci = flat_axes[2]
+    ax_se = flat_axes[2]
     ax_sm = flat_axes[3]
 
     _ps.style_panel_axes(ax_tracks, specs[_ps.TRACKS_INDEX][0])
@@ -73,11 +73,11 @@ def save_numerical_diagnostics(
     _ps.draw_quiver_overlay(ax_mean, stats.mean_dx, stats.mean_dy)
 
     _draw_field_panel(
-        fig, ax_ci,
-        data=ci95_vec,
-        cmap=specs[_ps.CI95_INDEX][1],
-        title=specs[_ps.CI95_INDEX][0],
-        unit=specs[_ps.CI95_INDEX][2],
+        fig, ax_se,
+        data=se_vec,
+        cmap=specs[_ps.SE_INDEX][1],
+        title=specs[_ps.SE_INDEX][0],
+        unit=specs[_ps.SE_INDEX][2],
     )
 
     if vbar_sm is not None:

--- a/src/opennta/application/tab_analysis/dialogs/numerical/dialog.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/dialog.py
@@ -4,7 +4,7 @@ import pandas as pd
 from PyQt5.QtWidgets import QDialog, QMessageBox
 
 from opennta.analysis.numerical_field.field_smoother import (
-    ci95_weighted_gaussian_smooth,
+    se_weighted_gaussian_smooth,
 )
 from opennta.analysis.numerical_field.field_stats import component_stats
 from opennta.analysis.numerical_field.types import (
@@ -111,10 +111,10 @@ class NumericalFieldDialog(
             return
 
         try:
-            self.smoothed_u, self.smoothed_v = ci95_weighted_gaussian_smooth(
+            self.smoothed_u, self.smoothed_v = se_weighted_gaussian_smooth(
                 mean_dx=self.stats.mean_dx,
                 mean_dy=self.stats.mean_dy,
-                ci95_vec=self.stats.ci95_vec,
+                se_vec=self.stats.se_vec,
                 count=self.stats.count,
                 min_count=self.sb_mincount.value(),
                 ksize=self.sb_ksize.value(),


### PR DESCRIPTION
## Summary
This PR refactors the numerical field analysis to use standard error (SE) instead of 95% confidence interval (CI95) for weighting in the Gaussian smoothing algorithm. The change clarifies the statistical meaning of the weighting parameter and improves code documentation.

## Key Changes
- Renamed function `ci95_weighted_gaussian_smooth()` to `se_weighted_gaussian_smooth()` in `field_smoother.py`
- Updated all parameter names from `ci95_vec` to `se_vec` throughout the codebase
- Changed `FieldStats` dataclass field from `ci95_vec` to `se_vec`
- Removed the intermediate `ci95_vec = 1.96 * se_vec` calculation in `velocity_field.py` since SE is now used directly
- Updated UI labels and documentation:
  - Changed "CI-weighted smoothing" to "SE-weighted smoothing"
  - Updated plot spec from "CI₉₅" to "Standard error"
  - Updated weight formula documentation from `1 / (CI95² + ε)` to `1 / (SE² + ε)`
- Updated all imports and function calls across the application

## Implementation Details
The weighting formula uses inverse-variance (precision) weighting: `1 / (SE² + ε)`, where SE is the standard error of the cell's mean velocity. This is mathematically equivalent to the previous CI95-based approach (since CI95 = 1.96 × SE), but using SE directly is more statistically transparent and eliminates unnecessary multiplication by the constant factor 1.96.

All changes maintain backward compatibility in functionality while improving code clarity and statistical accuracy.

https://claude.ai/code/session_017EKhFwepQbrZfkyqNy88Cp