### PR TITLE
Remove unit label from UV statistics panel title

### DIFF
--- a/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
@@ -187,8 +187,8 @@ class _UIBuilderMixin:
     _UV_STATS_LABEL_U = "u<sub>x</sub>"
     _UV_STATS_LABEL_V = "u<sub>y</sub>"
 
-    # Shown in the title in every state (placeholder and populated) so the unit
-    # is always visible and the title length never changes when values arrive.
+    # Shown in the table corner in every state (placeholder and populated) so
+    # the unit stays visible and the layout never changes when values arrive.
     _UV_STATS_UNIT = "µm/s"
 
     def _build_uv_stats_label(self) -> QLabel:
@@ -203,9 +203,9 @@ class _UIBuilderMixin:
         return lbl
 
     def _clear_uv_stats(self) -> None:
-        # Same table as the populated state -- same title (with unit) and same
-        # row count -- but with placeholder cells, so the reserved height
-        # matches and nothing jumps once values arrive.
+        # Same table as the populated state -- same corner unit and row count --
+        # but with placeholder cells, so the reserved height matches and nothing
+        # jumps once values arrive.
         self.lbl_uv_stats.setText(
             self._format_uv_stats_html(None, None, self._UV_STATS_UNIT)
         )
@@ -225,11 +225,13 @@ class _UIBuilderMixin:
         self.lbl_uv_stats.setText(self._format_uv_stats_html(u_stats, v_stats, unit))
 
     def _format_uv_stats_html(self, u_stats, v_stats, unit: str) -> str:
-        title = f"{self._UV_STATS_LABEL_U}, {self._UV_STATS_LABEL_V} statistics"
-        if unit:
-            title += f" ({unit})"
+        # The unit lives in the otherwise-empty corner cell rather than a title
+        # line above the table: the "u_x, u_y statistics (unit)" title was long
+        # enough to wrap and clip inside the narrow left panel, and the row
+        # labels already name the components, so only the unit is worth keeping.
+        corner = unit if unit else "&nbsp;"
         # font-weight:normal drops the default bold <th> face so the header
-        # row matches the un-bolded row labels and title.
+        # row matches the un-bolded row labels.
         header_cells = "".join(
             f"<th align='right' width='{self._UV_STATS_DATA_COL_WIDTH}' "
             f"style='font-weight:normal;'>{col}</th>"
@@ -237,7 +239,8 @@ class _UIBuilderMixin:
         )
         header = (
             f"<tr><th align='left' width='{self._UV_STATS_LABEL_COL_WIDTH}' "
-            f"style='font-weight:normal;'>&nbsp;</th>{header_cells}</tr>"
+            f"style='font-weight:normal; color:{_ps.FG_MUTED};'>{corner}</th>"
+            f"{header_cells}</tr>"
         )
         body = (
             self._uv_stats_row(self._UV_STATS_LABEL_U, u_stats)
@@ -245,7 +248,6 @@ class _UIBuilderMixin:
         )
         # 11px matches the other left-panel labels; family is inherited.
         return (
-            f"<div style='color:{_ps.FG_MUTED}; font-size:11px;'>{title}</div>"
             "<table width='100%' cellspacing='0' cellpadding='2' "
             "style='font-size:11px;'>"
             f"{header}{body}</table>"

--- a/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
@@ -187,10 +187,6 @@ class _UIBuilderMixin:
     _UV_STATS_LABEL_U = "u<sub>x</sub>"
     _UV_STATS_LABEL_V = "u<sub>y</sub>"
 
-    # Shown in the table corner in every state (placeholder and populated) so
-    # the unit stays visible and the layout never changes when values arrive.
-    _UV_STATS_UNIT = "µm/s"
-
     def _build_uv_stats_label(self) -> QLabel:
         lbl = QLabel()
         lbl.setTextFormat(Qt.RichText)
@@ -203,12 +199,10 @@ class _UIBuilderMixin:
         return lbl
 
     def _clear_uv_stats(self) -> None:
-        # Same table as the populated state -- same corner unit and row count --
-        # but with placeholder cells, so the reserved height matches and nothing
-        # jumps once values arrive.
-        self.lbl_uv_stats.setText(
-            self._format_uv_stats_html(None, None, self._UV_STATS_UNIT)
-        )
+        # Same table as the populated state -- same row count -- but with
+        # placeholder cells, so the reserved height matches and nothing jumps
+        # once values arrive.
+        self.lbl_uv_stats.setText(self._format_uv_stats_html(None, None))
 
     def _reserve_uv_stats_height(self) -> None:
         # Lock the stats box to the height of the placeholder table so that
@@ -221,15 +215,13 @@ class _UIBuilderMixin:
         if height > 0:
             self.lbl_uv_stats.setFixedHeight(height)
 
-    def _set_uv_stats(self, u_stats, v_stats, unit: str = "") -> None:
-        self.lbl_uv_stats.setText(self._format_uv_stats_html(u_stats, v_stats, unit))
+    def _set_uv_stats(self, u_stats, v_stats) -> None:
+        self.lbl_uv_stats.setText(self._format_uv_stats_html(u_stats, v_stats))
 
-    def _format_uv_stats_html(self, u_stats, v_stats, unit: str) -> str:
-        # The unit lives in the otherwise-empty corner cell rather than a title
-        # line above the table: the "u_x, u_y statistics (unit)" title was long
-        # enough to wrap and clip inside the narrow left panel, and the row
-        # labels already name the components, so only the unit is worth keeping.
-        corner = unit if unit else "&nbsp;"
+    def _format_uv_stats_html(self, u_stats, v_stats) -> str:
+        # No title row and an empty corner cell keep the panel compact in the
+        # narrow left column: the row labels already name the u_x/u_y components
+        # and the column headers are self-evident.
         # font-weight:normal drops the default bold <th> face so the header
         # row matches the un-bolded row labels.
         header_cells = "".join(
@@ -239,8 +231,7 @@ class _UIBuilderMixin:
         )
         header = (
             f"<tr><th align='left' width='{self._UV_STATS_LABEL_COL_WIDTH}' "
-            f"style='font-weight:normal; color:{_ps.FG_MUTED};'>{corner}</th>"
-            f"{header_cells}</tr>"
+            f"style='font-weight:normal;'>&nbsp;</th>{header_cells}</tr>"
         )
         body = (
             self._uv_stats_row(self._UV_STATS_LABEL_U, u_stats)

--- a/src/opennta/application/tab_analysis/dialogs/numerical/dialog.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/dialog.py
@@ -104,7 +104,7 @@ class NumericalFieldDialog(
         fps = float(self.config.fps)
         u_stats = component_stats(self.stats.mean_dx * fps)
         v_stats = component_stats(self.stats.mean_dy * fps)
-        self._set_uv_stats(u_stats, v_stats, unit=self._UV_STATS_UNIT)
+        self._set_uv_stats(u_stats, v_stats)
 
     def _apply_smoothing(self) -> None:
         if self.stats is None:


### PR DESCRIPTION
## Summary
Simplifies the UV statistics display by removing the unit label from the panel title and eliminating the title row entirely, making the panel more compact while keeping the information clear through existing row and column labels.

## Key Changes
- Removed the `_UV_STATS_UNIT` constant that was used to display "µm/s" in the title
- Removed the title row from the HTML table output in `_format_uv_stats_html()`
- Simplified method signatures by removing the `unit` parameter from `_set_uv_stats()` and `_format_uv_stats_html()`
- Updated comments to reflect that row labels already identify the u_x/u_y components and column headers are self-evident
- Removed the unit parameter when calling `_set_uv_stats()` in the dialog update method

## Implementation Details
The change maintains the same visual layout and height reservation behavior while reducing visual clutter. The UV component names (u_x, u_y) are already present as row labels, and the statistical measures are clear from column headers, making a separate title row with unit redundant. This keeps the left panel more compact without losing information clarity.

https://claude.ai/code/session_01D29FHKnzdV4mUTDvRbioEs