### PR TITLE
Refactor interpolation controls from QGroupBox to QWidget

### DIFF
--- a/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
@@ -103,13 +103,13 @@ class _UIBuilderMixin:
         col.setSpacing(8)
 
         params_box, _ = self._build_field_group()
-        interp_box = self._build_interp_group()
+        interp_controls = self._build_interp_controls()
         smooth_box = self._build_smoothing_group()
 
         col.addWidget(params_box)
         col.addWidget(smooth_box)
         col.addWidget(self._build_vectors_button())
-        col.addWidget(interp_box)
+        col.addWidget(interp_controls)
         col.addStretch(1)
 
         col.addWidget(self._build_export_checkbox())
@@ -265,18 +265,22 @@ class _UIBuilderMixin:
         )
         return f"<tr>{label}{cells}</tr>"
 
-    def _build_interp_group(self) -> QGroupBox:
+    def _build_interp_controls(self) -> QWidget:
+        # Frameless inline control (no QGroupBox): a plain "Interpolation"
+        # checkbox above the nodes field. Dropping the box keeps the narrow
+        # left column compact, matching the field panel that shed its stats
+        # title/unit, while the checkbox preserves the old group-box toggle.
         self._last_interp_nodes = self._INTERP_DEFAULT_NODES
 
-        box = QGroupBox("Interpolation")
-        box.setCheckable(True)
-        box.setChecked(True)
-        box.setCursor(Qt.PointingHandCursor)
-        self.chk_interp = box
-
-        vbox = QVBoxLayout(box)
-        vbox.setContentsMargins(10, 12, 10, 10)
+        wrap = QWidget()
+        vbox = QVBoxLayout(wrap)
+        vbox.setContentsMargins(0, 0, 0, 0)
         vbox.setSpacing(6)
+
+        self.chk_interp = QCheckBox("Interpolation")
+        self.chk_interp.setChecked(True)
+        self.chk_interp.setCursor(Qt.PointingHandCursor)
+        vbox.addWidget(self.chk_interp)
 
         form_wrap = QWidget()
         form = QFormLayout(form_wrap)
@@ -295,10 +299,13 @@ class _UIBuilderMixin:
         form.addRow("nodes", self.le_nodes)
         vbox.addWidget(form_wrap)
 
-        box.toggled.connect(self._on_interp_toggled)
+        # Connect after setChecked so the initial state doesn't fire the toggle
+        # handler before le_nodes exists; checked=True already matches the
+        # field's default enabled state.
+        self.chk_interp.toggled.connect(self._on_interp_toggled)
         self.le_nodes.textEdited.connect(self._on_nodes_edited)
 
-        return box
+        return wrap
 
     def _on_grid_param_changed(self, *_args) -> None:
         self._sync_node_default()

--- a/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
@@ -266,10 +266,6 @@ class _UIBuilderMixin:
         return f"<tr>{label}{cells}</tr>"
 
     def _build_interp_controls(self) -> QWidget:
-        # Frameless inline control (no QGroupBox): a plain "Interpolation"
-        # checkbox above the nodes field. Dropping the box keeps the narrow
-        # left column compact, matching the field panel that shed its stats
-        # title/unit, while the checkbox preserves the old group-box toggle.
         self._last_interp_nodes = self._INTERP_DEFAULT_NODES
 
         wrap = QWidget()
@@ -299,9 +295,6 @@ class _UIBuilderMixin:
         form.addRow("nodes", self.le_nodes)
         vbox.addWidget(form_wrap)
 
-        # Connect after setChecked so the initial state doesn't fire the toggle
-        # handler before le_nodes exists; checked=True already matches the
-        # field's default enabled state.
         self.chk_interp.toggled.connect(self._on_interp_toggled)
         self.le_nodes.textEdited.connect(self._on_nodes_edited)
 


### PR DESCRIPTION
## Summary
Refactored the interpolation controls UI component to use a simpler QWidget-based layout instead of a QGroupBox, improving flexibility and consistency with the overall UI design.

## Key Changes
- Renamed `_build_interp_group()` method to `_build_interp_controls()` to better reflect its new structure
- Replaced `QGroupBox` with a `QWidget` wrapper for the interpolation controls
- Converted the checkable group box into a standalone `QCheckBox` widget for the "Interpolation" label
- Updated layout margins from `(10, 12, 10, 10)` to `(0, 0, 0, 0)` for the wrapper widget
- Connected the checkbox's `toggled` signal instead of the group box's signal to maintain the same toggle behavior
- Updated the return type annotation from `QGroupBox` to `QWidget`

## Implementation Details
- The checkbox state and cursor behavior remain unchanged
- The form layout for interpolation parameters is preserved within the new structure
- All signal connections (`toggled` and `textEdited`) continue to work as before
- The refactoring maintains the same visual hierarchy while providing a more modular component structure

https://claude.ai/code/session_0138VYVLfYkPaTAQuV2B92Tj