### PR TITLE
Fix UV stats label clipping and refactor interpolation controls layout

### DIFF
--- a/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
@@ -204,6 +204,12 @@ class _UIBuilderMixin:
         # once values arrive.
         self.lbl_uv_stats.setText(self._format_uv_stats_html(None, None))
 
+    # Subscripts (the "y" in u_y) dip below the rich-text baseline, but
+    # QLabel.heightForWidth measures from that baseline and does not count the
+    # descender, so the bottom row's tail is clipped by the fixed height. Pad
+    # the reservation by a few pixels to keep that glyph fully visible.
+    _UV_STATS_HEIGHT_PAD = 4
+
     def _reserve_uv_stats_height(self) -> None:
         # Lock the stats box to the height of the placeholder table so that
         # "Compute field" only swaps dashes for values and never grows the box,
@@ -213,7 +219,7 @@ class _UIBuilderMixin:
         # set, while the placeholder is showing.
         height = self.lbl_uv_stats.heightForWidth(self._LEFT_MIN_W)
         if height > 0:
-            self.lbl_uv_stats.setFixedHeight(height)
+            self.lbl_uv_stats.setFixedHeight(height + self._UV_STATS_HEIGHT_PAD)
 
     def _set_uv_stats(self, u_stats, v_stats) -> None:
         self.lbl_uv_stats.setText(self._format_uv_stats_html(u_stats, v_stats))
@@ -269,22 +275,16 @@ class _UIBuilderMixin:
         self._last_interp_nodes = self._INTERP_DEFAULT_NODES
 
         wrap = QWidget()
-        vbox = QVBoxLayout(wrap)
-        vbox.setContentsMargins(0, 0, 0, 0)
-        vbox.setSpacing(6)
+        row = QHBoxLayout(wrap)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(0)
 
         self.chk_interp = QCheckBox("Interpolation")
         self.chk_interp.setChecked(True)
         self.chk_interp.setCursor(Qt.PointingHandCursor)
-        vbox.addWidget(self.chk_interp)
 
-        form_wrap = QWidget()
-        form = QFormLayout(form_wrap)
-        form.setContentsMargins(0, 0, 0, 0)
-        form.setHorizontalSpacing(8)
-        form.setVerticalSpacing(6)
-        form.setLabelAlignment(Qt.AlignRight | Qt.AlignVCenter)
-        form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        nodes_label = QLabel("nodes")
+        nodes_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
 
         self.le_nodes = QLineEdit()
         self.le_nodes.setValidator(QIntValidator(2, 8192, self.le_nodes))
@@ -292,8 +292,15 @@ class _UIBuilderMixin:
         self.le_nodes.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         self.le_nodes.setText(str(self._last_interp_nodes))
 
-        form.addRow("nodes", self.le_nodes)
-        vbox.addWidget(form_wrap)
+        # Single row: the "Interpolation" toggle on the left, the node count on
+        # the right. The field expands to fill the panel width like the inputs
+        # above it; the wider gap groups "nodes" with its field rather than the
+        # checkbox.
+        row.addWidget(self.chk_interp)
+        row.addSpacing(16)
+        row.addWidget(nodes_label)
+        row.addSpacing(8)
+        row.addWidget(self.le_nodes, 1)
 
         self.chk_interp.toggled.connect(self._on_interp_toggled)
         self.le_nodes.textEdited.connect(self._on_nodes_edited)


### PR DESCRIPTION
## Summary
This PR addresses a text rendering issue in the UV statistics label and refactors the interpolation controls layout for better visual organization.

## Key Changes

- **UV Stats Height Padding**: Added a 4-pixel padding constant (`_UV_STATS_HEIGHT_PAD`) to the fixed height calculation of the UV statistics label. This prevents subscript characters (like the "y" in u_y) from being clipped at the bottom due to how `QLabel.heightForWidth()` measures from the baseline without accounting for descenders.

- **Interpolation Controls Layout Refactor**: Converted the interpolation controls from a vertical layout with a nested form layout to a single horizontal row layout:
  - Changed from `QVBoxLayout` → `QHBoxLayout`
  - Removed the nested `QFormLayout` wrapper
  - Replaced form row with explicit widget positioning using spacing
  - The checkbox now appears on the left with the "nodes" label and input field on the right
  - Adjusted spacing (16px gap between checkbox and label, 8px between label and field) to visually group the label with its input field

## Implementation Details

The interpolation controls now use a simpler, flatter layout structure that better aligns with the panel's width expansion behavior. The spacing strategy creates a visual hierarchy where the wider gap between the checkbox and the "nodes" label groups the label-field pair together, improving the UI's visual clarity.

https://claude.ai/code/session_01SG4E8J1NAnrUG8bsLF45my