### PR TITLE
Fix fit curve CSV x spacing at 0.1

### DIFF
--- a/src/opennta/tracking/trackmate/fitting.py
+++ b/src/opennta/tracking/trackmate/fitting.py
@@ -17,6 +17,7 @@ from .types import FitResult, ThresholdResult
 
 ModelType = Any
 logger = logging.getLogger(__name__)
+FIT_CURVE_X_STEP = 0.1
 
 
 class FittingEngine:
@@ -203,7 +204,21 @@ class FittingEngine:
         xlo = float(np.quantile(u, 0.01))
         xmed = float(np.median(u))
         xhi = float(xmed + 3 * (xmed - xlo))
-        grid = np.linspace(xlo, xhi, 500)
+        # A fixed point count made the exported x spacing depend on each
+        # dataset's quality range.  In narrow ranges those densely packed
+        # values can also look duplicated after spreadsheet/display rounding.
+        # Anchor the samples to decimal tenths so the CSV has one unambiguous
+        # point per x value and a consistent resolution across datasets.
+        grid_start = np.ceil(xlo / FIT_CURVE_X_STEP) * FIT_CURVE_X_STEP
+        grid_stop = np.floor(xhi / FIT_CURVE_X_STEP) * FIT_CURVE_X_STEP
+        grid = np.arange(
+            grid_start,
+            grid_stop + FIT_CURVE_X_STEP / 2,
+            FIT_CURVE_X_STEP,
+        )
+        if grid.size == 0:
+            grid = np.array([grid_start])
+        grid = np.round(grid, decimals=10)
         dens = self.model.pdf_untruncated(grid, **params)
 
         n_total = int(u.size)

--- a/tests/unit/tracking/trackmate/test_fitting_engine.py
+++ b/tests/unit/tracking/trackmate/test_fitting_engine.py
@@ -74,3 +74,19 @@ def test_solve_threshold_returns_nan_on_unbracketable_root():
     # sign for a large alpha, so brentq cannot bracket → graceful NaN.
     out = engine.solve_threshold_for_tail_prob(0.9, 80.0, 100.0, **params)
     assert np.isnan(out)
+
+
+def test_exported_fit_csv_uses_unique_decimal_tenths(tmp_path):
+    values, *_ = _synth.quality_samples(seed=4)
+    engine = FittingEngine("Gaussian")
+    result = engine.calculate_threshold(
+        values,
+        alpha=1e-4,
+        quality_csv_path=str(tmp_path / "frame_quality.csv"),
+    )
+    exported = np.loadtxt(result.fit_csv_path, delimiter=",")
+    grid = exported[:, 0]
+
+    assert np.unique(grid).size == grid.size
+    assert np.diff(grid) == pytest.approx(0.1)
+    assert grid * 10 == pytest.approx(np.round(grid * 10))


### PR DESCRIPTION
### Motivation
- The fit-curve export used a fixed sample count (`np.linspace(xlo, xhi, 500)`) so the exported x spacing varied with the data range, producing very small steps for narrow ranges that appeared duplicated after spreadsheet/plot rounding.
- The goal is to produce a consistent, human-friendly x grid at 0.1 increments so exported CSVs have unambiguous, unique x values.

### Description
- Replace the 500-point `linspace` with a decimal-tenth anchored grid using a new `FIT_CURVE_X_STEP = 0.1` constant and `np.arange` aligned to tenths (`grid_start`, `grid_stop`).
- Round generated x coordinates (`np.round(..., decimals=10)`) to avoid floating-point artifacts that could make nearby values look identical.
- Ensure a non-empty grid fallback when the computed interval is too small so the plotting/export code always has at least one x value.
- Add a regression unit test `test_exported_fit_csv_uses_unique_decimal_tenths` that generates the fit CSV via `calculate_threshold` and asserts the exported x column is unique and spaced by `0.1`.

### Testing
- Ran the fitting unit tests with `python -m pytest tests/unit/tracking/trackmate/test_fitting_engine.py -q`, which passed (`8 passed`).
- Ran static checks with `python -m ruff check src/opennta/tracking/trackmate/fitting.py tests/unit/tracking/trackmate/test_fitting_engine.py`, which passed.
- Attempting a full `python -m pytest -q` failed collection for GUI-related tests due to a missing system library (`libGL.so.1`) preventing `PyQt5` imports, but the modified TrackMate fitting tests and added regression test passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67cb54169c8322b8c6f0d45ea48686)