### PR TITLE
Add No Fitting (FRAC) threshold mode

### DIFF
--- a/src/opennta/application/tab_tracking/dialogs/trackmate/preview_worker.py
+++ b/src/opennta/application/tab_tracking/dialogs/trackmate/preview_worker.py
@@ -141,7 +141,12 @@ class TrackMatePreviewWorker(QThread):
             spots_x = df[xcol].to_numpy(dtype=float)
             spots_y = df[ycol].to_numpy(dtype=float)
 
-            self._emit_log(f"Preview: fitting noise distribution ({self.params.quality_model})")
+            if self.params.quality_model == "No Fitting (FRAC)":
+                self._emit_log("Preview: using the empirical FRAC quantile")
+            else:
+                self._emit_log(
+                    f"Preview: fitting noise distribution ({self.params.quality_model})"
+                )
             engine = FittingEngine(self.params.quality_model)
             fit_result = engine.calculate_threshold(
                 u=qualities,
@@ -152,7 +157,11 @@ class TrackMatePreviewWorker(QThread):
 
             grid = None
             density = None
-            if fit_result.converged and np.isfinite(fit_result.u_star_alpha):
+            if (
+                not engine.uses_empirical_frac
+                and fit_result.converged
+                and np.isfinite(fit_result.u_star_alpha)
+            ):
                 xlo = float(np.quantile(qualities, 0.01))
                 xmed = float(np.median(qualities))
                 xhi = float(xmed + 3 * (xmed - xlo))

--- a/src/opennta/tracking/trackmate/fitting.py
+++ b/src/opennta/tracking/trackmate/fitting.py
@@ -37,6 +37,10 @@ class FittingEngine:
     def param_names(self) -> list[str]:
         return self.model.param_names
 
+    @property
+    def uses_empirical_frac(self) -> bool:
+        return bool(getattr(self.model, "uses_empirical_frac", False))
+
     def _params_to_dict(self, params_array: NDArray[np.floating]) -> dict[str, float]:
         return {name: float(val) for name, val in zip(self.param_names, params_array, strict=False)}
 
@@ -145,6 +149,9 @@ class FittingEngine:
         frac: float | None = None,
         quality_csv_path: str | None = None,
     ) -> ThresholdResult:
+        if self.uses_empirical_frac:
+            return self._calculate_empirical_frac_threshold(u, frac, alpha)
+
         fit_result = self.fit(u, frac)
         params = fit_result.params
 
@@ -189,6 +196,40 @@ class FittingEngine:
             n_total=n_total,
             n_ge_thresh=n_hi,
             n_lt_thresh=n_lo,
+            model_name=self.model_name,
+        )
+
+    def _calculate_empirical_frac_threshold(
+        self,
+        u: NDArray[np.floating],
+        frac: float | None,
+        alpha: float,
+    ) -> ThresholdResult:
+        """Use the requested empirical quantile directly, without fitting."""
+        values = np.asarray(u, dtype=float)
+        values = values[np.isfinite(values)]
+        if values.size == 0:
+            raise ValueError("No finite quality values available")
+
+        quantile = self.model.default_frac if frac is None else float(frac)
+        if not 0.0 <= quantile <= 1.0:
+            raise ValueError(f"FRAC must be between 0 and 1, got {quantile}")
+
+        threshold = float(np.quantile(values, quantile))
+        n_hi = int(np.sum(values >= threshold))
+        n_total = int(values.size)
+        return ThresholdResult(
+            ok=True,
+            converged=True,
+            params={},
+            u_cut_fit_range=threshold,
+            u_star_alpha=threshold,
+            alpha=alpha,
+            plot_path=None,
+            fit_csv_path=None,
+            n_total=n_total,
+            n_ge_thresh=n_hi,
+            n_lt_thresh=n_total - n_hi,
             model_name=self.model_name,
         )
 

--- a/src/opennta/tracking/trackmate/fitting_models.py
+++ b/src/opennta/tracking/trackmate/fitting_models.py
@@ -292,7 +292,20 @@ class GaussianModel:
         return params["sigma"] > 0
 
 
+class NoFittingFracModel:
+    """Marker model that uses the empirical FRAC quantile as the threshold."""
+
+    model_name = "No Fitting (FRAC)"
+    default_frac = 0.85
+    uses_empirical_frac = True
+
+    @property
+    def param_names(self) -> list[str]:
+        return []
+
+
 MODEL_CLASSES = {
+    "No Fitting (FRAC)": NoFittingFracModel,
     "Cheng-Schwartzman": ChengSchwartzmanModel,
     "Poly2": Poly2Model,
     "Gaussian": GaussianModel,
@@ -304,4 +317,3 @@ def get_model_class(name: str):
         available = ", ".join(MODEL_CLASSES.keys())
         raise ValueError(f"Unknown model: {name}. Available: {available}")
     return MODEL_CLASSES[name]
-

--- a/tests/unit/tracking/trackmate/test_fitting_engine.py
+++ b/tests/unit/tracking/trackmate/test_fitting_engine.py
@@ -50,6 +50,29 @@ def test_calculate_threshold_separates_bulk_from_spike(model_name):
     assert result.n_ge_thresh + result.n_lt_thresh == result.n_total
 
 
+def test_no_fitting_frac_uses_empirical_quantile_as_threshold():
+    values = np.arange(1.0, 101.0)
+    engine = FittingEngine("No Fitting (FRAC)")
+
+    result = engine.calculate_threshold(values, frac=0.85, alpha=1e-4)
+
+    assert result.ok and result.converged
+    assert result.params == {}
+    assert result.u_star_alpha == pytest.approx(np.quantile(values, 0.85))
+    assert result.u_cut_fit_range == result.u_star_alpha
+    assert result.n_ge_thresh == 15
+    assert result.n_lt_thresh == 85
+    assert result.plot_path is None
+    assert result.fit_csv_path is None
+
+
+def test_no_fitting_frac_rejects_out_of_range_fraction():
+    engine = FittingEngine("No Fitting (FRAC)")
+
+    with pytest.raises(ValueError, match="FRAC must be between 0 and 1"):
+        engine.calculate_threshold(np.arange(10.0), frac=1.1, alpha=0.05)
+
+
 def test_neg_log_likelihood_rejects_invalid_sigma():
     values, *_ = _synth.quality_samples(seed=3)
     engine = FittingEngine("Gaussian")


### PR DESCRIPTION
### Motivation
- Provide a lightweight thresholding mode that skips distribution fitting and uses the requested `FRAC` empirical quantile directly as the quality threshold (e.g. `FRAC=0.85` → choose the 85th percentile, so the top 15% are selected).

### Description
- Add `NoFittingFracModel` to `src/opennta/tracking/trackmate/fitting_models.py` and register it in `MODEL_CLASSES` as `"No Fitting (FRAC)"`, with `default_frac = 0.85` and a marker attribute `uses_empirical_frac=True`.
- Extend `FittingEngine` in `src/opennta/tracking/trackmate/fitting.py` with an `uses_empirical_frac` property and branch `calculate_threshold` to call `_calculate_empirical_frac_threshold` when the model requests it; implement `_calculate_empirical_frac_threshold` to compute the empirical quantile, count `n_ge_thresh`/`n_lt_thresh`, and return a `ThresholdResult` with empty `params` and no plot/CSV outputs.
- Adjust preview behavior in `src/opennta/application/tab_tracking/dialogs/trackmate/preview_worker.py` to log the empirical mode and avoid rendering a fit curve when the engine is in empirical-FRAC mode.
- Add unit tests in `tests/unit/tracking/trackmate/test_fitting_engine.py` covering that the FRAC-only mode returns the empirical quantile as the threshold and that out-of-range `FRAC` values raise a `ValueError`.

### Testing
- Ran lint/check: `ruff check src/opennta/tracking/trackmate/fitting.py src/opennta/tracking/trackmate/fitting_models.py src/opennta/application/tab_tracking/dialogs/trackmate/preview_worker.py tests/unit/tracking/trackmate/test_fitting_engine.py` — passed.
- Ran targeted unit tests: `pytest -q tests/unit/tracking/trackmate/test_fitting_engine.py tests/unit/tracking/trackmate/test_threshold_calculator.py` — all tests passed (17 passed).
- Ran the tracking-related test suite: `pytest -q tests/unit/tracking tests/contracts tests/integration/test_trackmate_tracking.py` — passed (74 passed, 2 skipped because external Fiji is unavailable in CI).
- Note: a full `pytest -q` run in this environment hit collection failures for a few GUI-focused application tests due to a missing system library (`libGL.so.1`) causing PyQt5 import errors; this is an environment issue and not a regression in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6902ea04fc83228b3bf1f73fcb73bd)