### PR TITLE
Add unsmoothed velocity component statistics

### DIFF
--- a/src/opennta/analysis/numerical_field/types.py
+++ b/src/opennta/analysis/numerical_field/types.py
@@ -22,6 +22,15 @@ class FieldStats:
     ci95_vec: NDArray[np.floating]
 
 
+@dataclass(frozen=True)
+class ComponentExtrema:
+    """Finite extrema for one component of a gridded velocity field."""
+
+    minimum: float
+    maximum: float
+    span: float
+
+
 @dataclass
 class NumericalFieldParams:
     # Captured from the dialog once and reused across batch files.
@@ -43,4 +52,4 @@ class NumericalFieldParams:
         return int(self.n_windows)
 
 
-__all__ = ["FieldStats", "NumericalFieldParams"]
+__all__ = ["ComponentExtrema", "FieldStats", "NumericalFieldParams"]

--- a/src/opennta/analysis/numerical_field/velocity_field.py
+++ b/src/opennta/analysis/numerical_field/velocity_field.py
@@ -3,7 +3,37 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from .types import FieldStats, NumericalFieldParams
+from .types import ComponentExtrema, FieldStats, NumericalFieldParams
+
+
+def component_extrema(
+    values: np.ndarray,
+    *,
+    scale: float = 1.0,
+) -> ComponentExtrema:
+    """Return min, max, and max difference for the finite grid cells.
+
+    ``values`` is normally an unsmoothed component produced by
+    :func:`compute_velocity_field`. Empty windows are represented by NaN and
+    deliberately excluded. ``scale`` allows the stored µm/frame values to be
+    presented as µm/s without modifying the field itself.
+    """
+    finite = np.asarray(values, dtype=float)
+    finite = finite[np.isfinite(finite)] * float(scale)
+    if finite.size == 0:
+        return ComponentExtrema(
+            minimum=float("nan"),
+            maximum=float("nan"),
+            span=float("nan"),
+        )
+
+    minimum = float(np.min(finite))
+    maximum = float(np.max(finite))
+    return ComponentExtrema(
+        minimum=minimum,
+        maximum=maximum,
+        span=maximum - minimum,
+    )
 
 
 def compute_velocity_field(
@@ -99,4 +129,9 @@ def compute_velocity_field(
     )
 
 
-__all__ = ["FieldStats", "NumericalFieldParams", "compute_velocity_field"]
+__all__ = [
+    "FieldStats",
+    "NumericalFieldParams",
+    "component_extrema",
+    "compute_velocity_field",
+]

--- a/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py
@@ -103,10 +103,12 @@ class _UIBuilderMixin:
         col.setSpacing(8)
 
         params_box, _ = self._build_field_group()
+        statistics_box = self._build_statistics_group()
         interp_box = self._build_interp_group()
         smooth_box = self._build_smoothing_group()
 
         col.addWidget(params_box)
+        col.addWidget(statistics_box)
         col.addWidget(smooth_box)
         col.addWidget(self._build_vectors_button())
         col.addWidget(interp_box)
@@ -172,6 +174,42 @@ class _UIBuilderMixin:
         )
 
         return box, form
+
+    def _build_statistics_group(self) -> QGroupBox:
+        box = QGroupBox("Unsmoothed mean statistics")
+        grid = QGridLayout(box)
+        grid.setContentsMargins(10, 12, 10, 10)
+        grid.setHorizontalSpacing(12)
+        grid.setVerticalSpacing(4)
+
+        headers = ("Component", "Minimum", "Maximum", "Max difference")
+        for column, text in enumerate(headers):
+            label = QLabel(text)
+            label.setAlignment(Qt.AlignCenter)
+            grid.addWidget(label, 0, column)
+
+        self.lbl_component_stats: dict[str, tuple[QLabel, QLabel, QLabel]] = {}
+        for row, component in enumerate(("X", "Y"), start=1):
+            name = QLabel(component)
+            name.setAlignment(Qt.AlignCenter)
+            grid.addWidget(name, row, 0)
+
+            values = tuple(QLabel("—") for _ in range(3))
+            for column, label in enumerate(values, start=1):
+                label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+                label.setMinimumWidth(48)
+                grid.addWidget(label, row, column)
+            self.lbl_component_stats[component.lower()] = values
+
+        unit = QLabel("µm/s (finite window means; before smoothing)")
+        unit.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        unit.setStyleSheet("color: rgba(255,255,255,0.60);")
+        grid.addWidget(unit, 3, 0, 1, 4)
+        grid.setColumnStretch(0, 1)
+        grid.setColumnStretch(1, 1)
+        grid.setColumnStretch(2, 1)
+        grid.setColumnStretch(3, 2)
+        return box
 
     def _build_interp_group(self) -> QGroupBox:
         self._last_interp_nodes = self._INTERP_DEFAULT_NODES

--- a/src/opennta/application/tab_analysis/dialogs/numerical/dialog.py
+++ b/src/opennta/application/tab_analysis/dialogs/numerical/dialog.py
@@ -10,7 +10,10 @@ from opennta.analysis.numerical_field.types import (
     FieldStats,
     NumericalFieldParams,
 )
-from opennta.analysis.numerical_field.velocity_field import compute_velocity_field
+from opennta.analysis.numerical_field.velocity_field import (
+    component_extrema,
+    compute_velocity_field,
+)
 
 from ....common.fonts import get_app_font
 from ._plot_builder import _PlotBuilderMixin
@@ -90,7 +93,22 @@ class NumericalFieldDialog(
         self.smoothed_u = None
         self.smoothed_v = None
         self._use_smoothed = False
+        self._refresh_component_statistics()
         self._redraw()
+
+    def _refresh_component_statistics(self) -> None:
+        for component, values in self.lbl_component_stats.items():
+            if self.stats is None:
+                texts = ("—", "—", "—")
+            else:
+                field = self.stats.mean_dx if component == "x" else self.stats.mean_dy
+                extrema = component_extrema(field, scale=float(self.config.fps))
+                texts = tuple(
+                    "—" if pd.isna(value) else f"{value:.3f}"
+                    for value in (extrema.minimum, extrema.maximum, extrema.span)
+                )
+            for label, text in zip(values, texts, strict=True):
+                label.setText(text)
 
     def _apply_smoothing(self) -> None:
         if self.stats is None:

--- a/tests/unit/analysis/numerical_field/test_velocity_field.py
+++ b/tests/unit/analysis/numerical_field/test_velocity_field.py
@@ -19,7 +19,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from opennta.analysis.numerical_field.velocity_field import compute_velocity_field
+from opennta.analysis.numerical_field.velocity_field import (
+    component_extrema,
+    compute_velocity_field,
+)
 
 
 def _single_window_df(good_dx, good_dy, *, outlier_dx, outlier_dy, n_outlier):
@@ -57,3 +60,21 @@ def test_mad_outlier_rejection_protects_window_mean():
     contaminated = compute_velocity_field(df, outlier_k=1e9, **grid)
     assert contaminated.mean_dx[0, 0] == pytest.approx((20 * 1.0 + 2 * 100.0) / 22)
     assert contaminated.mean_dy[0, 0] == pytest.approx((20 * 2.0 + 2 * -100.0) / 22)
+
+
+def test_component_extrema_ignores_empty_windows_and_preserves_sign():
+    values = np.array([[np.nan, -1.5], [0.25, 2.0]])
+
+    extrema = component_extrema(values, scale=4.0)
+
+    assert extrema.minimum == pytest.approx(-6.0)
+    assert extrema.maximum == pytest.approx(8.0)
+    assert extrema.span == pytest.approx(14.0)
+
+
+def test_component_extrema_returns_nan_for_an_empty_field():
+    extrema = component_extrema(np.full((2, 2), np.nan), scale=25.0)
+
+    assert np.isnan(extrema.minimum)
+    assert np.isnan(extrema.maximum)
+    assert np.isnan(extrema.span)


### PR DESCRIPTION
### Motivation
- Provide quick, per-component extrema (min, max, max difference) for the unsmoothed gridded velocity field so users can inspect raw X/Y component ranges before any smoothing is applied.
- Exclude empty windows (NaN) from these stats and preserve signed values while allowing conversion from µm/frame to µm/s for display.
- Surface the values in the Numerical Drift Field UI so they are visible and understandable alongside existing diagnostic plots.

### Description
- Add a frozen dataclass `ComponentExtrema` in `src/opennta/analysis/numerical_field/types.py` to hold `minimum`, `maximum`, and `span` for a single component.
- Implement `component_extrema(values, *, scale=1.0)` in `src/opennta/analysis/numerical_field/velocity_field.py` to compute finite-cell min/max/span while ignoring `NaN` and applying an optional scale (used for FPS conversion).
- Export `component_extrema` from the numerical field module and add `ComponentExtrema` to `__all__`.
- Add a new `Unsmoothed mean statistics` group to the numerical dialog UI in `src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py` and wire it in the dialog (`_refresh_component_statistics`) to compute and display X/Y extrema in µm/s (FPS-scaled, formatted to 3 decimals) immediately after `Compute field` runs.
- Add unit tests in `tests/unit/analysis/numerical_field/test_velocity_field.py` covering `component_extrema` behavior with mixed NaNs, sign preservation, scaling, and the empty-field NaN outputs, and adjust imports to exercise the new function.

### Testing
- Ran `ruff check src/opennta/analysis/numerical_field/types.py src/opennta/analysis/numerical_field/velocity_field.py src/opennta/application/tab_analysis/dialogs/numerical/_ui_builder.py src/opennta/application/tab_analysis/dialogs/numerical/dialog.py tests/unit/analysis/numerical_field/test_velocity_field.py` which passed.
- Ran `pytest -q tests/unit/analysis/numerical_field/test_velocity_field.py` and the file's tests passed (`3 passed`).
- Ran `python -m compileall -q src/opennta/analysis/numerical_field src/opennta/application/tab_analysis/dialogs/numerical` and `git diff --check`, both succeeded.
- Full `pytest -q` could not collect Qt-dependent application tests in this environment because `libGL.so.1` is missing, causing import errors during collection for GUI tests (so application-level tests were not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70f3551e9c8322b0d215434121718d)