### PR TITLE
Account for camera exposure (motion blur) in diffusion analysis and config

### DIFF
--- a/src/opennta/analysis/diffusion_estimator.py
+++ b/src/opennta/analysis/diffusion_estimator.py
@@ -38,7 +38,9 @@ class DiffusionEstimator:
                 insufficient.append((pid, use_n))
                 continue
 
-            t = lags[:use_n] * self.config.dt
+            t = np.asarray(
+                [self.config.effective_lag_time(int(lag)) for lag in lags[:use_n]]
+            )
             y = msds[:use_n]
             slope, _ = np.polyfit(t, y, 1)
             D = slope / 4

--- a/src/opennta/analysis/mle/ftla_distributor.py
+++ b/src/opennta/analysis/mle/ftla_distributor.py
@@ -95,7 +95,8 @@ class FTLADistributor(SizeDistributor):
         phys = PhysicalParams(
             temp_K=float(config.temp),
             eta_Pa_s=float(config.eta),
-            tau_s=float(config.dt),
+            frame_interval_s=float(config.dt),
+            exposure_time_s=float(config.exposure_time),
             kB=float(config.KB),
             noise_m2=4.0 * loc_err_m * loc_err_m,
         )

--- a/src/opennta/analysis/mle/iterative_distributor.py
+++ b/src/opennta/analysis/mle/iterative_distributor.py
@@ -108,7 +108,8 @@ class IterativeDistributor(SizeDistributor):
         phys = PhysicalParams(
             temp_K=float(config.temp),
             eta_Pa_s=float(config.eta),
-            tau_s=float(config.dt),
+            frame_interval_s=float(config.dt),
+            exposure_time_s=float(config.exposure_time),
             kB=float(config.KB),
             # 2D displacement with per-coord SD sigma_e contributes 4 sigma_e^2.
             noise_m2=4.0 * loc_err_m * loc_err_m,

--- a/src/opennta/analysis/mle/types.py
+++ b/src/opennta/analysis/mle/types.py
@@ -13,14 +13,24 @@ class PhysicalParams:
 
     temp_K: float
     eta_Pa_s: float
-    tau_s: float
+    frame_interval_s: float
+    exposure_time_s: float = 0.0
     kB: float = 1.380649e-23
     noise_m2: float = 0.0  # additive per-frame variance from localization error
 
-    def msd_scale(self, d_m: NDArray[np.floating]) -> NDArray[np.floating]:
-        # s(d) = 4 D(d) tau + noise_m2, D(d) = kB T / (3 pi eta d). Inputs in m, m^2 out.
+    def effective_lag_time(self, lag: int = 1) -> float:
+        return lag * self.frame_interval_s - self.exposure_time_s / 3.0
+
+    def msd_scale(
+        self, d_m: NDArray[np.floating], lag: int = 1
+    ) -> NDArray[np.floating]:
+        effective_time = self.effective_lag_time(lag)
+        if effective_time <= 0:
+            raise ValueError("Effective lag time must be positive.")
+
+        # D(d) = kB T / (3 pi eta d). Inputs in m, m^2 out.
         D = (self.kB * self.temp_K) / (3.0 * np.pi * self.eta_Pa_s * d_m)
-        return 4.0 * D * self.tau_s + self.noise_m2
+        return 4.0 * D * effective_time + self.noise_m2
 
 
 __all__ = ["PhysicalParams"]

--- a/src/opennta/analysis/types.py
+++ b/src/opennta/analysis/types.py
@@ -12,6 +12,7 @@ class AnalysisConfig:
     sensor_size: float = field(default=6.5, metadata={"user_config": True})
     magnification: float = field(default=20, metadata={"user_config": True})
     fps: float = field(default=25.0, metadata={"user_config": True})
+    exposure_time: float = field(default=0.0, metadata={"user_config": True})
     temp: float = field(default=295.15, metadata={"user_config": True})
     eta: float = field(default=0.0009544, metadata={"user_config": True})
     KB: float = 1.380649e-23
@@ -21,6 +22,14 @@ class AnalysisConfig:
     def __post_init__(self) -> None:
         self.pixel_size = self.sensor_size / self.magnification
         self.dt = 1.0 / self.fps
+
+        if self.exposure_time < 0:
+            raise ValueError("Exposure time must be non-negative.")
+        if self.exposure_time > self.dt:
+            raise ValueError("Exposure time cannot exceed the frame interval.")
+
+    def effective_lag_time(self, lag: int = 1) -> float:
+        return lag * self.dt - self.exposure_time / 3.0
 
 
 def user_config_fields(cls) -> tuple[str, ...]:

--- a/src/opennta/analysis/units.py
+++ b/src/opennta/analysis/units.py
@@ -27,6 +27,16 @@ CONFIG_UNITS: dict[str, UnitSpec] = {
     "sensor_size": UnitSpec("µm", "µm", {"µm": (1.0, 0.0), "um": (1.0, 0.0)}),
     "magnification": UnitSpec("X", "X", {"X": (1.0, 0.0), "": (1.0, 0.0)}),
     "fps": UnitSpec("Hz", "Hz", {"Hz": (1.0, 0.0), "fps": (1.0, 0.0), "": (1.0, 0.0)}),
+    "exposure_time": UnitSpec(
+        "s",
+        "ms",
+        {
+            "s": (1.0, 0.0),
+            "ms": (1e-3, 0.0),
+            "µs": (1e-6, 0.0),
+            "us": (1e-6, 0.0),
+        },
+    ),
     "temp": UnitSpec(
         "K", "K",
         {"K": (1.0, 0.0), "°C": (1.0, 273.15), "C": (1.0, 273.15), "celsius": (1.0, 273.15)},

--- a/src/opennta/application/config/_ui_builder.py
+++ b/src/opennta/application/config/_ui_builder.py
@@ -15,7 +15,7 @@ class _UIBuilderMixin:
 
     _WINDOW_TITLE = "Configure"
     _WINDOW_INIT_W = 390
-    _WINDOW_INIT_H = 270
+    _WINDOW_INIT_H = 310
     _FONT_FAMILY = "SansSerif"
 
     _UPDATE_ACCENT = "rgb(17, 103, 255)"
@@ -24,6 +24,7 @@ class _UIBuilderMixin:
         ("le_sensor_size", "Sensor pixel size", "µm"),
         ("le_magnification", "Lens magnification", "X"),
         ("le_fps", "Frame per second", ""),
+        ("le_exposure_time", "Exposure time", "ms"),
         ("le_temp", "Temperature", "K"),
         ("le_eta", "Viscosity", "mPa·s"),
     )
@@ -73,4 +74,3 @@ class _UIBuilderMixin:
             row.addWidget(btn)
 
         return row
-

--- a/src/opennta/application/config/dialog.py
+++ b/src/opennta/application/config/dialog.py
@@ -17,6 +17,7 @@ class ConfigDialog(_UIBuilderMixin, QDialog):
         "le_sensor_size": "sensor_size",
         "le_magnification": "magnification",
         "le_fps": "fps",
+        "le_exposure_time": "exposure_time",
         "le_temp": "temp",
         "le_eta": "eta",
     }

--- a/tests/unit/analysis/mle/test_likelihood.py
+++ b/tests/unit/analysis/mle/test_likelihood.py
@@ -24,7 +24,36 @@ from opennta.analysis.mle.types import PhysicalParams
 
 def _phys(noise_m2: float = 0.0) -> PhysicalParams:
     return PhysicalParams(
-        temp_K=298.0, eta_Pa_s=8.9e-4, tau_s=1.0 / 30.0, noise_m2=noise_m2
+        temp_K=298.0,
+        eta_Pa_s=8.9e-4,
+        frame_interval_s=1.0 / 30.0,
+        noise_m2=noise_m2,
+    )
+
+
+def test_physical_params_applies_uniform_exposure_motion_blur():
+    phys = PhysicalParams(
+        temp_K=298.0,
+        eta_Pa_s=8.9e-4,
+        frame_interval_s=0.040,
+        exposure_time_s=0.040,
+    )
+    diameter_m = np.asarray([100e-9])
+    diffusion = phys.kB * phys.temp_K / (3.0 * np.pi * phys.eta_Pa_s * diameter_m)
+
+    assert phys.effective_lag_time() == pytest.approx(0.040 - 0.040 / 3.0)
+    assert phys.msd_scale(diameter_m) == pytest.approx(
+        4.0 * diffusion * (0.040 - 0.040 / 3.0)
+    )
+
+
+def test_zero_exposure_preserves_unblurred_msd_scale():
+    phys = _phys()
+    diameter_m = np.asarray([100e-9])
+    diffusion = phys.kB * phys.temp_K / (3.0 * np.pi * phys.eta_Pa_s * diameter_m)
+
+    assert phys.msd_scale(diameter_m) == pytest.approx(
+        4.0 * diffusion * phys.frame_interval_s
     )
 
 

--- a/tests/unit/analysis/test_diffusion_estimator.py
+++ b/tests/unit/analysis/test_diffusion_estimator.py
@@ -6,6 +6,7 @@ import pytest
 
 from opennta.analysis.diffusion_estimator import DiffusionEstimator
 from opennta.analysis.msd_calculator import MSDCalculator
+from opennta.analysis.types import AnalysisConfig
 from opennta.tests._helpers.synth import brownian_tracks_df_corr
 
 
@@ -87,3 +88,18 @@ def test_uses_at_most_lag_frame_points(default_analysis_config):
     D_short, *_ = DiffusionEstimator(default_analysis_config).estimate(short, lag_frame=2)
     D_long, *_ = DiffusionEstimator(default_analysis_config).estimate(long, lag_frame=2)
     assert D_short[1] == pytest.approx(D_long[1])
+
+
+def test_blur_shifted_multilag_msd_recovers_diffusion():
+    config = AnalysisConfig(fps=25.0, exposure_time=0.040)
+    diffusion = 0.5
+    lags = np.arange(1, 5)
+    msds = 4.0 * diffusion * (
+        lags * config.dt - config.exposure_time / 3.0
+    ) + 0.02
+
+    estimated, *_ = DiffusionEstimator(config).estimate(
+        {1: (lags, msds)}, lag_frame=4
+    )
+
+    assert estimated[1] == pytest.approx(diffusion)

--- a/tests/unit/application/test_config_manager.py
+++ b/tests/unit/application/test_config_manager.py
@@ -53,6 +53,7 @@ def test_get_config_converts_display_units_to_canonical(isolated_config_dir):
         "sensor_size": {"value": 6.5, "unit": "µm"},
         "magnification": {"value": 20, "unit": "X"},
         "fps": {"value": 30.0, "unit": "Hz"},
+        "exposure_time": {"value": 40.0, "unit": "ms"},
         "temp": {"value": 25.0, "unit": "°C"},
         "eta": {"value": 0.89, "unit": "mPa·s"},
     }
@@ -61,6 +62,7 @@ def test_get_config_converts_display_units_to_canonical(isolated_config_dir):
     config = manager.get_config()
     assert config.eta == pytest.approx(0.00089)      # 0.89 mPa·s -> Pa·s
     assert config.temp == pytest.approx(298.15)      # 25 °C -> K
+    assert config.exposure_time == pytest.approx(0.040)  # 40 ms -> s
 
 
 def test_get_config_rejects_unknown_unit(isolated_config_dir):
@@ -75,16 +77,19 @@ def test_get_config_rejects_unknown_unit(isolated_config_dir):
 
 def test_get_config_round_trip_returns_analysis_config(isolated_config_dir):
     manager = ConfigManager(parent=None)
-    manager.save_to_temp({field: 1.5 for field in _USER_FIELDS})
+    data = {field: 1.5 for field in _USER_FIELDS}
+    data["exposure_time"] = 0.1
+    manager.save_to_temp(data)
 
     config = manager.get_config()
 
     assert isinstance(config, AnalysisConfig)
-    for field in _USER_FIELDS:
+    assert config.exposure_time == pytest.approx(0.1)
+    for field in set(_USER_FIELDS) - {"exposure_time"}:
         assert getattr(config, field) == pytest.approx(1.5)
 
 
-def test_get_config_raises_on_missing_keys(isolated_config_dir):
+def test_get_config_raises_on_missing_required_keys(isolated_config_dir):
     manager = ConfigManager(parent=None)
     # Intentionally drop a required user field; get_config must refuse to
     # silently fall back so a corrupted config file is surfaced loudly.
@@ -92,4 +97,27 @@ def test_get_config_raises_on_missing_keys(isolated_config_dir):
     manager.save_to_temp(partial)
 
     with pytest.raises(RuntimeError, match="missing required keys"):
+        manager.get_config()
+
+
+def test_get_config_rejects_missing_exposure_time(isolated_config_dir):
+    manager = ConfigManager(parent=None)
+    legacy = {
+        field: getattr(AnalysisConfig(), field)
+        for field in _USER_FIELDS
+        if field != "exposure_time"
+    }
+    manager.save_to_temp(legacy)
+
+    with pytest.raises(RuntimeError, match="missing required keys: exposure_time"):
+        manager.get_config()
+
+
+def test_get_config_rejects_exposure_longer_than_frame_interval(isolated_config_dir):
+    manager = ConfigManager(parent=None)
+    data = cm_mod.config_to_persisted(AnalysisConfig())
+    data["exposure_time"] = {"value": 41.0, "unit": "ms"}
+    manager.save_to_temp(data)
+
+    with pytest.raises(RuntimeError, match="cannot exceed the frame interval"):
         manager.get_config()


### PR DESCRIPTION
### Motivation
- Model motion blur from finite exposure time by exposing an `exposure_time` parameter so effective lag time used in MSD fits reflects exposure averaging. 
- Ensure user-config, UI and unit conversion round-trips carry `exposure_time` and validate it against the frame interval. 
- Use the corrected effective lag time consistently in direct conversion and MLE likelihood code so recovered diffusion/diameter estimates are unbiased.

### Description
- Added `exposure_time` to `AnalysisConfig` with validation that it is non-negative and does not exceed the frame interval and introduced `effective_lag_time(lag)` on the config. 
- Added `exposure_time` unit spec to `analysis.units` and updated the config UI (`_ui_builder.py`) to include an exposure time field and slightly increased dialog height. 
- Extended `PhysicalParams` (MLE types) to accept `frame_interval_s` and `exposure_time_s`, implemented `effective_lag_time` and changed `msd_scale` to use the effective lag time (raising on non-positive effective time). 
- Updated callers to the MLE code (`ftla_distributor.py`, `iterative_distributor.py`) to pass `frame_interval_s` and `exposure_time_s`, and updated `diffusion_estimator.estimate` to build the time vector from `config.effective_lag_time(...)` rather than raw `dt`. 
- Updated and added unit tests to cover the new API and motion-blur behavior and updated config manager tests to validate unit conversion and missing/invalid exposure-time handling.

### Testing
- Ran the updated unit tests including `tests/unit/analysis/mle/test_likelihood.py`, `tests/unit/analysis/test_diffusion_estimator.py`, and `tests/unit/application/test_config_manager.py` under `pytest` and all tests passed. 
- Added tests that verify `PhysicalParams.effective_lag_time` and `msd_scale` behave correctly with full exposure blur and with zero exposure, and a test that `DiffusionEstimator` recovers diffusion when multi-lag MSDs are shifted by the blur correction. 
- Added config-manager tests that verify display-unit conversion for `exposure_time`, missing-key rejection, and rejection when `exposure_time` exceeds the frame interval.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9b2b29b5b48322af059a8b9e43c985)